### PR TITLE
Carriers config endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dev/
+.env
 *~
 tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ CMD ["npm", "start"]
 ENV NODE_ENV=production
 
 # Setup application dependencies
-copy package*.json /opt/project/
+COPY package*.json /opt/project/
 RUN npm --unsafe-perm install --only production
 
 # Setup the application code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ services:
   console:
     image: swaggerapi/swagger-ui
     ports:
-      - "3000:8080"
+      - "${PORT-3000}:8080"
     environment:
       - URL=http://localhost:8080/openapi.json

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -5,9 +5,7 @@ info:
   description: |
     The GFW Settings API exposes settings and metadata about the GFW platform. This comes in 2 flavours: global settings, such as service discovery, and dataset metadata.
 
-
 definitions:
-
   PlatformSettings:
     type: object
     required:
@@ -96,6 +94,156 @@ definitions:
           List of event types supported by this dataset.
         items:
           type: string
+
+  FlagState:
+    type: object
+    description: Coastal countries to include in the search options
+    required:
+      - id
+      - label
+    properties:
+      id:
+        description: ISO 3 code
+        type: string
+        example: TWN
+      label:
+        description: Name for the country
+        type: string
+        example: Taiwan
+      alias:
+        description: Alias for the country
+        type: string
+        example: Chinese Taipei
+
+  FlagStateGroup:
+    type: object
+    required:
+      - id
+      - name
+      - isos
+    properties:
+      id:
+        description: Unique identifier for the group
+        type: string
+        example: yellow-card
+      name:
+        description: Name for the group
+        type: string
+        example: Yellow card
+      descripcion:
+        description: Brief description of why the countries are grouped in each group
+        type: string
+        example: List of countries below the yellow card warning
+      isos:
+        description: List of ISOs 3 which belongs to the group
+        type: array
+        items:
+          type: string
+          minLength: 3
+          maxLength: 3
+        example: ['CHN', 'CHL']
+
+  RFMOs:
+    type: string
+    description: |
+      List of supported rfmos, including one for the events which are not within any of them
+    enum:
+      - iccat
+      - iotc
+      - wcpfc
+      - iattc
+      - ccsbt
+      - none
+
+  PointCoordinate:
+    type: object
+    required:
+      - lat
+      - lng
+    properties:
+      lat:
+        type: number
+        format: float
+        example: 40.389737
+      lng:
+        type: number
+        format: float
+        example: -3.695042
+
+  Port:
+    type: object
+    required:
+      - id
+      - label
+      - coordinates
+    properties:
+      id:
+        type: string
+        example: port-1
+      label:
+        type: string
+        example: Port 1
+      iso:
+        type: string
+        description: ISO 3 which the port belongs to
+        example: CHL
+      rfmo:
+        $ref: '#/definitions/RFMOs'
+      coordinates:
+        $ref: '#/definitions/PointCoordinate'
+
+  PortalConfig:
+    type: object
+    required:
+      - rfmos
+      - ports
+      - flagStates
+      - flagStateGroups
+    properties:
+      rfmos:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - label
+          properties:
+            id:
+              $ref: '#/definitions/RFMOs'
+            label:
+              type: string
+              example: ICCAT
+            alias:
+              description: Aliases to match the rfmo name, as other languages acronyms
+              type: array
+              items:
+                type: string
+                example:
+                  [
+                    'CICAA',
+                    'CICTA',
+                    'International Commission for the Conservation of Atlantic Tunas',
+                  ]
+            bounds:
+              description: Boundig box of the area
+              type: array
+              items:
+                type: array
+                items:
+                  type: number
+              example: [[86.1509, -98.0859], [-82.9834, 68.2031]]
+      ports:
+        type: array
+        items:
+          $ref: '#/definitions/Port'
+      flagStates:
+        type: array
+        items:
+          $ref: '#/definitions/FlagState'
+      flagStateGroups:
+        type: array
+        items:
+          $ref: '#/definitions/FlagStateGroup'
 
   ValidationError:
     type: object
@@ -218,6 +366,36 @@ paths:
             Expected response to a successful request.
           schema:
             $ref: '#/definitions/Dataset'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  "/datasets/{dataset}/config":
+    get:
+      summary: |
+        Obtains params config related to the dataset
+      description: |
+        Obtains the list of params that are optionals to query or filter the dataset, for now only available for `carriers`
+      produces:
+        - application/json
+      parameters:
+        - name: dataset
+          in: path
+          description: |
+            Name of the dataset to query information about
+          required: true
+          type: string
+          enum:
+            - carriers
+      responses:
+        '200':
+          description: |
+            Expected response to a successful request.
+          schema:
+            $ref: '#/definitions/PortalConfig'
         '401':
           $ref: '#/responses/Unauthorized'
         '400':

--- a/src/data/config/flags.js
+++ b/src/data/config/flags.js
@@ -1,0 +1,1242 @@
+module.exports = {
+  async get() {
+    return [
+      {
+        "id": "ABW",
+        "label": "Aruba"
+      },
+      {
+        "id": "AFG",
+        "label": "Afghanistan"
+      },
+      {
+        "id": "AGO",
+        "label": "Angola"
+      },
+      {
+        "id": "AIA",
+        "label": "Anguilla"
+      },
+      {
+        "id": "ALA",
+        "label": "Åland Islands"
+      },
+      {
+        "id": "ALB",
+        "label": "Albania"
+      },
+      {
+        "id": "AND",
+        "label": "Andorra"
+      },
+      {
+        "id": "ARE",
+        "label": "United Arab Emirates"
+      },
+      {
+        "id": "ARG",
+        "label": "Argentina"
+      },
+      {
+        "id": "ARM",
+        "label": "Armenia",
+        "alias": "Hayastan"
+      },
+      {
+        "id": "ASM",
+        "label": "American Samoa",
+        "alias": "Amerika Sāmoa"
+      },
+      {
+        "id": "ATA",
+        "label": "Antarctica"
+      },
+      {
+        "id": "ATF",
+        "label": "French Southern and Antarctic Lands",
+        "alias": "Terres australes et antarctiques françaises"
+      },
+      {
+        "id": "ATG",
+        "label": "Antigua and Barbuda"
+      },
+      {
+        "id": "AUS",
+        "label": "Australia"
+      },
+      {
+        "id": "AUT",
+        "label": "Austria",
+        "alias": "Österreich"
+      },
+      {
+        "id": "AZE",
+        "label": "Azerbaijan",
+        "alias": "Azərbaycan"
+      },
+      {
+        "id": "BDI",
+        "label": "Burundi"
+      },
+      {
+        "id": "BEL",
+        "label": "Belgium",
+        "alias": ["België", "Belgique", "Belgien"]
+      },
+      {
+        "id": "BEN",
+        "label": "Benin"
+      },
+      {
+        "id": "BFA",
+        "label": "Burkina Faso"
+      },
+      {
+        "id": "BGD",
+        "label": "Bangladesh"
+      },
+      {
+        "id": "BGR",
+        "label": "Bulgaria",
+        "alias": "Bǎlgariya"
+      },
+      {
+        "id": "BHR",
+        "label": "Bahrain",
+        "alias": "Baḥrayn"
+      },
+      {
+        "id": "BHS",
+        "label": "Bahamas"
+      },
+      {
+        "id": "BIH",
+        "label": "Bosnia and Herzegovina",
+        "alias": "Hercegovina"
+      },
+      {
+        "id": "BLM",
+        "label": "Saint Barthélemy"
+      },
+      {
+        "id": "SHN",
+        "label": "Saint Helena Ascension and Tristan da Cunha"
+      },
+      {
+        "id": "BLR",
+        "label": "Belarus"
+      },
+      {
+        "id": "BLZ",
+        "label": "Belize"
+      },
+      {
+        "id": "BMU",
+        "label": "Bermuda"
+      },
+      {
+        "id": "BOL",
+        "label": "Bolivia"
+      },
+      {
+        "id": "BES",
+        "label": "Caribbean Netherlands",
+        "alias": "Caribisch Nederland"
+      },
+      {
+        "id": "BRA",
+        "label": "Brazil",
+        "alias": "Brasil"
+      },
+      {
+        "id": "BRB",
+        "label": "Barbados"
+      },
+      {
+        "id": "BRN",
+        "label": "Brunei"
+      },
+      {
+        "id": "BTN",
+        "label": "Bhutan",
+        "alias": "Druk Gyal Khap"
+      },
+      {
+        "id": "BVT",
+        "label": "Bouvet Island"
+      },
+      {
+        "id": "BWA",
+        "label": "Botswana"
+      },
+      {
+        "id": "CAF",
+        "label": "Central African Republic",
+        "alias": ["Ködörösêse tî Bêafrîka", "République centrafricaine"]
+      },
+      {
+        "id": "CAN",
+        "label": "Canada"
+      },
+      {
+        "id": "CCK",
+        "label": "Cocos (Keeling) Islands"
+      },
+      {
+        "id": "CHE",
+        "label": "Switzerland",
+        "alias": ["Schweizerische", "Suisse", "Svizzera", "Svizra", "Helvetica"]
+      },
+      {
+        "id": "CHL",
+        "label": "Chile"
+      },
+      {
+        "id": "CHN",
+        "label": "China",
+        "alias": "Zhōnghuá Rénmín Gònghéguó"
+      },
+      {
+        "id": "CIV",
+        "label": "Ivory Coast",
+        "alias": "Côte d'Ivoire"
+      },
+      {
+        "id": "CMR",
+        "label": "Cameroon",
+        "alias": "Cameroun"
+      },
+      {
+        "id": "COD",
+        "label": "DR Congo",
+        "alias": "Kôngo"
+      },
+      {
+        "id": "COG",
+        "label": "Republic of the Congo",
+        "alias": "Kôngo"
+      },
+      {
+        "id": "COK",
+        "label": "Cook Islands",
+        "alias": "Kūki 'Āirani"
+      },
+      {
+        "id": "COL",
+        "label": "Colombia"
+      },
+      {
+        "id": "COM",
+        "label": "Comoros",
+        "alias": ["Qumurī", "Komori"]
+      },
+      {
+        "id": "CPV",
+        "label": "Cape Verde",
+        "alias": "Kabu Verdi"
+      },
+      {
+        "id": "CRI",
+        "label": "Costa Rica"
+      },
+      {
+        "id": "CUB",
+        "label": "Cuba"
+      },
+      {
+        "id": "CUW",
+        "label": "Curaçao"
+      },
+      {
+        "id": "CXR",
+        "label": "Christmas Island"
+      },
+      {
+        "id": "CYM",
+        "label": "Cayman Islands"
+      },
+      {
+        "id": "CYP",
+        "label": "Cyprus",
+        "alias": "Cumhuriyeti"
+      },
+      {
+        "id": "CZE",
+        "label": "Czech Republic",
+        "alias": "Česká"
+      },
+      {
+        "id": "DEU",
+        "label": "Germany",
+        "alias": "Deutschland"
+      },
+      {
+        "id": "DJI",
+        "label": "Djibouti",
+        "alias": ["Jabuuti", "Gabuutih"]
+      },
+      {
+        "id": "DMA",
+        "label": "Dominica"
+      },
+      {
+        "id": "DNK",
+        "label": "Denmark",
+        "alias": "Danmark"
+      },
+      {
+        "id": "DOM",
+        "label": "Dominican Republic",
+        "alias": "República Dominicana"
+      },
+      {
+        "id": "DZA",
+        "label": "Algeria",
+        "alias": "Algérienne"
+      },
+      {
+        "id": "ECU",
+        "label": "Ecuador",
+        "alias": ["Ikwayur", "Ekuatur"]
+      },
+      {
+        "id": "EGY",
+        "label": "Egypt"
+      },
+      {
+        "id": "ERI",
+        "label": "Eritrea"
+      },
+      {
+        "id": "ESH",
+        "label": "Western Sahara",
+        "alias": ["Taneẓroft Tutrimt", "Sahara Occidental"]
+      },
+      {
+        "id": "ESP",
+        "label": "Spain",
+        "alias": ["España"]
+      },
+      {
+        "id": "EST",
+        "label": "Estonia",
+        "alias": "Eesti"
+      },
+      {
+        "id": "ETH",
+        "label": "Ethiopia"
+      },
+      {
+        "id": "FIN",
+        "label": "Finland",
+        "alias": "Suomen"
+      },
+      {
+        "id": "FJI",
+        "label": "Fiji",
+        "alias": "Matanitu Tugalala o Viti"
+      },
+      {
+        "id": "FLK",
+        "label": "Falkland Islands"
+      },
+      {
+        "id": "FRA",
+        "label": "France",
+        "alias": "française"
+      },
+      {
+        "id": "FRO",
+        "label": "Faroe Islands"
+      },
+      {
+        "id": "FSM",
+        "label": "Micronesia"
+      },
+      {
+        "id": "GAB",
+        "label": "Gabon"
+      },
+      {
+        "id": "GBR",
+        "label": "United Kingdom"
+      },
+      {
+        "id": "GEO",
+        "label": "Georgia"
+      },
+      {
+        "id": "GGY",
+        "label": "Guernsey"
+      },
+      {
+        "id": "GHA",
+        "label": "Ghana"
+      },
+      {
+        "id": "GIB",
+        "label": "Gibraltar"
+      },
+      {
+        "id": "GIN",
+        "label": "Guinea",
+        "alias": "Guinée"
+      },
+      {
+        "id": "GLP",
+        "label": "Guadeloupe"
+      },
+      {
+        "id": "GMB",
+        "label": "Gambia"
+      },
+      {
+        "id": "GNB",
+        "label": "Guinea-Bissau"
+      },
+      {
+        "id": "GNQ",
+        "label": "Equatorial Guinea"
+      },
+      {
+        "id": "GRC",
+        "label": "Greece",
+        "alias": ["Ellinikí", "Hellas"]
+      },
+      {
+        "id": "GRD",
+        "label": "Grenada"
+      },
+      {
+        "id": "GRL",
+        "label": "Greenland",
+        "alias": ["Kalaallit Nunaat", "Grønland"]
+      },
+      {
+        "id": "GTM",
+        "label": "Guatemala"
+      },
+      {
+        "id": "GUF",
+        "label": "French Guiana",
+        "alias": "Guyane"
+      },
+      {
+        "id": "GUM",
+        "label": "Guam",
+        "alias": "Guåhån"
+      },
+      {
+        "id": "GUY",
+        "label": "Guyana"
+      },
+      {
+        "id": "HKG",
+        "label": "Hong Kong"
+      },
+      {
+        "id": "HMD",
+        "label": "Heard Island and McDonald Islands"
+      },
+      {
+        "id": "HND",
+        "label": "Honduras"
+      },
+      {
+        "id": "HRV",
+        "label": "Croatia",
+        "alias": "Hrvatska"
+      },
+      {
+        "id": "HTI",
+        "label": "Haiti",
+        "alias": "Ayiti"
+      },
+      {
+        "id": "HUN",
+        "label": "Hungary",
+        "alias": "Magyarország"
+      },
+      {
+        "id": "IDN",
+        "label": "Indonesia"
+      },
+      {
+        "id": "IMN",
+        "label": "Isle of Man"
+      },
+      {
+        "id": "IND",
+        "label": "India"
+      },
+      {
+        "id": "IOT",
+        "label": "British Indian Ocean Territory"
+      },
+      {
+        "id": "IRL",
+        "label": "Ireland",
+        "alias": ["Éire", "Airlann"]
+      },
+      {
+        "id": "IRN",
+        "label": "Iran"
+      },
+      {
+        "id": "IRQ",
+        "label": "Iraq"
+      },
+      {
+        "id": "ISL",
+        "label": "Iceland",
+        "alias": "Ísland"
+      },
+      {
+        "id": "ISR",
+        "label": "Israel"
+      },
+      {
+        "id": "ITA",
+        "label": "Italy",
+        "alias": "Italia"
+      },
+      {
+        "id": "JAM",
+        "label": "Jamaica"
+      },
+      {
+        "id": "JEY",
+        "label": "Jersey"
+      },
+      {
+        "id": "JOR",
+        "label": "Jordan"
+      },
+      {
+        "id": "JPN",
+        "label": "Japan",
+        "alias": ["Nippon", "Nihon"]
+      },
+      {
+        "id": "KAZ",
+        "label": "Kazakhstan",
+        "alias": "Qazaqstan"
+      },
+      {
+        "id": "KEN",
+        "label": "Kenya"
+      },
+      {
+        "id": "KGZ",
+        "label": "Kyrgyzstan",
+        "alias": "Kırğız"
+      },
+      {
+        "id": "KHM",
+        "label": "Cambodia",
+        "alias": ["kampuciə", "Cambodge"]
+      },
+      {
+        "id": "KIR",
+        "label": "Kiribati"
+      },
+      {
+        "id": "KNA",
+        "label": "Saint Kitts and Nevis"
+      },
+      {
+        "id": "KOR",
+        "label": "South Korea",
+        "alias": "Daehan Minguk"
+      },
+      {
+        "id": "UNK",
+        "label": "Kosovo"
+      },
+      {
+        "id": "KWT",
+        "label": "Kuwait"
+      },
+      {
+        "id": "LAO",
+        "label": "Laos"
+      },
+      {
+        "id": "LBN",
+        "label": "Lebanon",
+        "alias": ["Liban", "Lubnān"]
+      },
+      {
+        "id": "LBR",
+        "label": "Liberia"
+      },
+      {
+        "id": "LBY",
+        "label": "Libya"
+      },
+      {
+        "id": "LCA",
+        "label": "Saint Lucia"
+      },
+      {
+        "id": "LIE",
+        "label": "Liechtenstein"
+      },
+      {
+        "id": "LKA",
+        "label": "Sri Lanka"
+      },
+      {
+        "id": "LSO",
+        "label": "Lesotho"
+      },
+      {
+        "id": "LTU",
+        "label": "Lithuania",
+        "alias": "Lietuva"
+      },
+      {
+        "id": "LUX",
+        "label": "Luxembourg",
+        "alias": "Lëtzebuerg"
+      },
+      {
+        "id": "LVA",
+        "label": "Latvia",
+        "alias": "Latvijas"
+      },
+      {
+        "id": "MAC",
+        "label": "Macau"
+      },
+      {
+        "id": "MAF",
+        "label": "Saint Martin"
+      },
+      {
+        "id": "MAR",
+        "label": "Morocco"
+      },
+      {
+        "id": "MCO",
+        "label": "Monaco"
+      },
+      {
+        "id": "MDA",
+        "label": "Moldova"
+      },
+      {
+        "id": "MDG",
+        "label": "Madagascar"
+      },
+      {
+        "id": "MDV",
+        "label": "Maldives"
+      },
+      {
+        "id": "MEX",
+        "label": "Mexico"
+      },
+      {
+        "id": "MHL",
+        "label": "Marshall Islands"
+      },
+      {
+        "id": "MKD",
+        "label": "Macedonia"
+      },
+      {
+        "id": "MLI",
+        "label": "Mali"
+      },
+      {
+        "id": "MLT",
+        "label": "Malta"
+      },
+      {
+        "id": "MMR",
+        "label": "Myanmar",
+        "alias": "Burma"
+      },
+      {
+        "id": "MNE",
+        "label": "Montenegro",
+        "alias": "Crna Gora"
+      },
+      {
+        "id": "MNG",
+        "label": "Mongolia"
+      },
+      {
+        "id": "MNP",
+        "label": "Northern Mariana Islands"
+      },
+      {
+        "id": "MOZ",
+        "label": "Mozambique",
+        "alias": ["Mozambiki", "Msumbiji"]
+      },
+      {
+        "id": "MRT",
+        "label": "Mauritania",
+        "alias": "Mūrītānīyah"
+      },
+      {
+        "id": "MSR",
+        "label": "Montserrat"
+      },
+      {
+        "id": "MTQ",
+        "label": "Martinique"
+      },
+      {
+        "id": "MUS",
+        "label": "Mauritius"
+      },
+      {
+        "id": "MWI",
+        "label": "Malawi"
+      },
+      {
+        "id": "MYS",
+        "label": "Malaysia"
+      },
+      {
+        "id": "MYT",
+        "label": "Mayotte"
+      },
+      {
+        "id": "NAM",
+        "label": "Namibia"
+      },
+      {
+        "id": "NCL",
+        "label": "New Caledonia"
+      },
+      {
+        "id": "NER",
+        "label": "Niger"
+      },
+      {
+        "id": "NFK",
+        "label": "Norfolk Island"
+      },
+      {
+        "id": "NGA",
+        "label": "Nigeria",
+        "alias": ["Nijeriya", "Naìjíríyà"]
+      },
+      {
+        "id": "NIC",
+        "label": "Nicaragua"
+      },
+      {
+        "id": "NIU",
+        "label": "Niue"
+      },
+      {
+        "id": "NLD",
+        "label": "Netherlands",
+        "alias": "Nederland"
+      },
+      {
+        "id": "NOR",
+        "label": "Norway",
+        "alias": "Norge"
+      },
+      {
+        "id": "NPL",
+        "label": "Nepal"
+      },
+      {
+        "id": "NRU",
+        "label": "Nauru"
+      },
+      {
+        "id": "NZL",
+        "label": "New Zealand",
+        "alias": "Aotearoa"
+      },
+      {
+        "id": "OMN",
+        "label": "Oman",
+        "alias": "ʻUmān"
+      },
+      {
+        "id": "PAK",
+        "label": "Pakistan"
+      },
+      {
+        "id": "PAN",
+        "label": "Panama"
+      },
+      {
+        "id": "PCN",
+        "label": "Pitcairn Islands"
+      },
+      {
+        "id": "PER",
+        "label": "Peru"
+      },
+      {
+        "id": "PHL",
+        "label": "Philippines",
+        "alias": "Pilipinas"
+      },
+      {
+        "id": "PLW",
+        "label": "Palau"
+      },
+      {
+        "id": "PNG",
+        "label": "Papua New Guinea"
+      },
+      {
+        "id": "POL",
+        "label": "Poland",
+        "alias": "Polska"
+      },
+      {
+        "id": "PRI",
+        "label": "Puerto Rico"
+      },
+      {
+        "id": "PRK",
+        "label": "North Korea",
+        "alias": "PRK"
+      },
+      {
+        "id": "PRT",
+        "label": "Portugal"
+      },
+      {
+        "id": "PRY",
+        "label": "Paraguay"
+      },
+      {
+        "id": "PSE",
+        "label": "Palestine",
+        "alias": "Dawlat Filasṭīn"
+      },
+      {
+        "id": "PYF",
+        "label": "French Polynesia",
+        "alias": ["Polynésie française", "Pōrīnetia Farāni"]
+      },
+      {
+        "id": "QAT",
+        "label": "Qatar"
+      },
+      {
+        "id": "REU",
+        "label": "Réunion"
+      },
+      {
+        "id": "ROU",
+        "label": "Romania"
+      },
+      {
+        "id": "RUS",
+        "label": "Russia",
+        "alias": "Rossiya"
+      },
+      {
+        "id": "RWA",
+        "label": "Rwanda"
+      },
+      {
+        "id": "SAU",
+        "label": "Saudi Arabia",
+        "alias": "Arabīyah as-Saʿūdīyah"
+      },
+      {
+        "id": "SDN",
+        "label": "Sudan"
+      },
+      {
+        "id": "SEN",
+        "label": "Senegal"
+      },
+      {
+        "id": "SGP",
+        "label": "Singapore"
+      },
+      {
+        "id": "SGS",
+        "label": "South Georgia"
+      },
+      {
+        "id": "SJM",
+        "label": "Svalbard and Jan Mayen"
+      },
+      {
+        "id": "SLB",
+        "label": "Solomon Islands"
+      },
+      {
+        "id": "SLE",
+        "label": "Sierra Leone"
+      },
+      {
+        "id": "SLV",
+        "label": "El Salvador"
+      },
+      {
+        "id": "SMR",
+        "label": "San Marino"
+      },
+      {
+        "id": "SOM",
+        "label": "Somalia"
+      },
+      {
+        "id": "SPM",
+        "label": "Saint Pierre and Miquelon"
+      },
+      {
+        "id": "SRB",
+        "label": "Serbia",
+        "alias": "Srbija"
+      },
+      {
+        "id": "SSD",
+        "label": "South Sudan"
+      },
+      {
+        "id": "STP",
+        "label": "São Tomé and Príncipe"
+      },
+      {
+        "id": "SUR",
+        "label": "Suriname"
+      },
+      {
+        "id": "SVK",
+        "label": "Slovakia",
+        "alias": "Slovenská"
+      },
+      {
+        "id": "SVN",
+        "label": "Slovenia",
+        "alias": "Slovenija"
+      },
+      {
+        "id": "SWE",
+        "label": "Sweden",
+        "alias": "Sverige"
+      },
+      {
+        "id": "SWZ",
+        "label": "Eswatini"
+      },
+      {
+        "id": "SXM",
+        "label": "Sint Maarten"
+      },
+      {
+        "id": "SYC",
+        "label": "Seychelles"
+      },
+      {
+        "id": "SYR",
+        "label": "Syria"
+      },
+      {
+        "id": "TCA",
+        "label": "Turks and Caicos Islands"
+      },
+      {
+        "id": "TCD",
+        "label": "Chad"
+      },
+      {
+        "id": "TGO",
+        "label": "Togo"
+      },
+      {
+        "id": "THA",
+        "label": "Thailand"
+      },
+      {
+        "id": "TJK",
+        "label": "Tajikistan"
+      },
+      {
+        "id": "TKL",
+        "label": "Tokelau"
+      },
+      {
+        "id": "TKM",
+        "label": "Turkmenistan"
+      },
+      {
+        "id": "TLS",
+        "label": "Timor-Leste"
+      },
+      {
+        "id": "TON",
+        "label": "Tonga"
+      },
+      {
+        "id": "TTO",
+        "label": "Trinidad and Tobago"
+      },
+      {
+        "id": "TUN",
+        "label": "Tunisia",
+        "alias": "Tūnisīyah"
+      },
+      {
+        "id": "TUR",
+        "label": "Turkey",
+        "alias": "Türkiye"
+      },
+      {
+        "id": "TUV",
+        "label": "Tuvalu"
+      },
+      {
+        "id": "TWN",
+        "label": "Taiwan, Province of China",
+        "alias": "Taipei"
+      },
+      {
+        "id": "TZA",
+        "label": "Tanzania"
+      },
+      {
+        "id": "UGA",
+        "label": "Uganda"
+      },
+      {
+        "id": "UKR",
+        "label": "Ukraine",
+        "alias": "Ukrayina"
+      },
+      {
+        "id": "UMI",
+        "label": "United States Minor Outlying Islands"
+      },
+      {
+        "id": "URY",
+        "label": "Uruguay"
+      },
+      {
+        "id": "USA",
+        "label": "United States of America"
+      },
+      {
+        "id": "UZB",
+        "label": "Uzbekistan"
+      },
+      {
+        "id": "VAT",
+        "label": "Vatican City"
+      },
+      {
+        "id": "VCT",
+        "label": "Saint Vincent and the Grenadines"
+      },
+      {
+        "id": "VEN",
+        "label": "Venezuela"
+      },
+      {
+        "id": "VGB",
+        "label": "British Virgin Islands"
+      },
+      {
+        "id": "VIR",
+        "label": "United States Virgin Islands"
+      },
+      {
+        "id": "VNM",
+        "label": "Vietnam"
+      },
+      {
+        "id": "VUT",
+        "label": "Vanuatu"
+      },
+      {
+        "id": "WLF",
+        "label": "Wallis and Futuna"
+      },
+      {
+        "id": "WSM",
+        "label": "Samoa"
+      },
+      {
+        "id": "YEM",
+        "label": "Yemen"
+      },
+      {
+        "id": "ZAF",
+        "label": "South Africa"
+      },
+      {
+        "id": "ZMB",
+        "label": "Zambia"
+      },
+      {
+        "id": "ZWE",
+        "label": "Zimbabwe"
+      }
+    ]
+  },
+  async getGroups() {
+    return [
+      {
+        "id": "2017-top-10",
+        "name": "2016 Top 10 fishing nations",
+        "descripcion": "Source: The World Bank",
+        "isos": ["CHN", "IDN", "IND", "VNM", "USA", "RUS", "JPN", "PHL", "PER", "BGD"]
+      },
+      {
+        "id": "fao",
+        "name": "Flags of convenience",
+        "descripcion": "Source: ITF",
+        "isos": [
+          "ATG",
+          "BHS",
+          "BRB",
+          "BLZ",
+          "BMU",
+          "BOL",
+          "KHM",
+          "CYM",
+          "COM",
+          "CYP",
+          "GNQ",
+          "FRO",
+          "GEO",
+          "GIB",
+          "HND",
+          "JAM",
+          "LBN",
+          "LBR",
+          "MLT",
+          "MHL",
+          "MUS",
+          "MDA",
+          "MNG",
+          "MMR",
+          "PRK",
+          "PAN",
+          "STP",
+          "VCT",
+          "LKA",
+          "VUT"
+        ]
+      },
+      {
+        "id": "psma",
+        "name": "PSMA parties",
+        "descripcion": "Parties of the Port State Measures Agreement. Source: FAO",
+        "isos": [
+          "ALB",
+          "AUS",
+          "BHS",
+          "BRB",
+          "CPV",
+          "CHL",
+          "CRI",
+          "CUB",
+          "GRL",
+          "FRO",
+          "DJI",
+          "DMA",
+          "ECU",
+          "FJI",
+          "FRA",
+          "GAB",
+          "GMB",
+          "GHA",
+          "GRD",
+          "GIN",
+          "GUY",
+          "ISL",
+          "IDN",
+          "JPN",
+          "KEN",
+          "LBR",
+          "LBY",
+          "MDG",
+          "MDV",
+          "MRT",
+          "MUS",
+          "MNE",
+          "MOZ",
+          "MMR",
+          "NAM",
+          "NZL",
+          "NOR",
+          "OMN",
+          "PLW",
+          "PAN",
+          "PER",
+          "PHL",
+          "KOR",
+          "KNA",
+          "VCT",
+          "STP",
+          "SEN",
+          "SYC",
+          "SLE",
+          "SOM",
+          "ZAF",
+          "LKA",
+          "SDN",
+          "THA",
+          "TGO",
+          "TON",
+          "TUR",
+          "USA",
+          "URY",
+          "VUT",
+          "VNM"
+        ]
+      },
+      {
+        "id": "yellow-card-nations",
+        "name": "Yellow Card nations",
+        "descripcion": "List of countries below the yellow card warning. Source: European Commission",
+        "isos": ["KIR", "KNA", "LBR", "TTO", "VCT", "VNM"]
+      },
+      {
+        "id": "european-union",
+        "name": "European Union",
+        "descripcion": "",
+        "isos": [
+          "ITA",
+          "FRA",
+          "DEU",
+          "GBR",
+          "ESP",
+          "GRC",
+          "NLD",
+          "HRV",
+          "PRT",
+          "MLT",
+          "POL",
+          "AUT",
+          "SWE",
+          "CYP",
+          "CZE",
+          "BEL",
+          "DNK",
+          "HUN",
+          "ROU",
+          "FIN",
+          "BGR",
+          "LUX",
+          "SVN",
+          "LTU",
+          "EST",
+          "IRL",
+          "LVA",
+          "SVK"
+        ]
+      }
+    ]
+  },
+};

--- a/src/data/config/index.js
+++ b/src/data/config/index.js
@@ -1,14 +1,19 @@
-const flagsData = require("./flags");
-const rfmosData = require("./rfmos");
-const portsData = require("./ports");
+const flagsData = require('./flags');
+const rfmosData = require('./rfmos');
+const portsData = require('./ports');
 
 module.exports = {
   async get() {
-    return {
-      ports: await portsData.get(),
-      rfmos: await rfmosData.get(),
-      flagStates: await flagsData.get(),
-      flagStateGroups: await flagsData.getGroups(),
+    try {
+      const [ports, rfmos, flagStates, flagStateGroups] = await Promise.all([
+        portsData.get(),
+        rfmosData.get(),
+        flagsData.get(),
+        flagsData.getGroups()
+      ]);
+      return { ports, rfmos, flagStates, flagStateGroups };
+    } catch(error) {
+      log.error(`Error getting config: ${error}`);
     }
   }
 };

--- a/src/data/config/index.js
+++ b/src/data/config/index.js
@@ -1,0 +1,14 @@
+const flagsData = require("./flags");
+const rfmosData = require("./rfmos");
+const portsData = require("./ports");
+
+module.exports = {
+  async get() {
+    return {
+      ports: await portsData.get(),
+      rfmos: await rfmosData.get(),
+      flagStates: await flagsData.get(),
+      flagStateGroups: await flagsData.getGroups(),
+    }
+  }
+};

--- a/src/data/config/ports.js
+++ b/src/data/config/ports.js
@@ -1,0 +1,56 @@
+module.exports = {
+  async get() {
+    return [
+      {
+        "id": "port-1",
+        "label": "Port 1",
+        "iso": "CHL",
+        "rfmo": "iccat",
+        "coordinates": {
+          "lat": 40.389737,
+          "lng": -3.695042
+        }
+      },
+      {
+        "id": "port-2",
+        "label": "Port 2",
+        "iso": "CHN",
+        "rfmo": "iccat",
+        "coordinates": {
+          "lat": 40.389737,
+          "lng": -3.695042
+        }
+      },
+      {
+        "id": "port-3",
+        "label": "Port 3",
+        "iso": "COL",
+        "rfmo": "iccat",
+        "coordinates": {
+          "lat": 40.389737,
+          "lng": -3.695042
+        }
+      },
+      {
+        "id": "port-4",
+        "label": "Port 4",
+        "iso": "CHN",
+        "rfmo": "iccat",
+        "coordinates": {
+          "lat": 40.389737,
+          "lng": -3.695042
+        }
+      },
+      {
+        "id": "port-5",
+        "label": "Port 5",
+        "iso": "ESP",
+        "rfmo": "iccat",
+        "coordinates": {
+          "lat": 40.389737,
+          "lng": -3.695042
+        }
+      }
+    ]
+  },
+};

--- a/src/data/config/rfmos.js
+++ b/src/data/config/rfmos.js
@@ -1,0 +1,49 @@
+module.exports = {
+  async get() {
+    return [
+      {
+        "id": "ICCAT",
+        "label": "ICCAT",
+        "alias": [
+          "CICAA",
+          "CICTA",
+          "International Commission for the Conservation of Atlantic Tunas",
+          "Comisión Internacional para la Conservación del Atún Atlántico",
+          "Commission internationale pour la conservation des thonidés de l’Atlantique"
+        ],
+        "bounds": [[86.1509, -98.0859], [-82.9834, 68.2031]]
+      },
+      {
+        "id": "IOTC",
+        "label": "IOTC",
+        "alias": ["CTOI", "Indian Ocean Tuna Commission", "Commission des Thons de l’Océan Indien"],
+        "bounds": [[30.6001, 19.8633], [-54.7753, 149.7656]]
+      },
+      {
+        "id": "WCPFC",
+        "label": "WCPFC",
+        "alias": "Western & Central Pacific Fisheries Commission",
+        "bounds": [[85.2152, 99.0967], [-60.0648, -129.7266]]
+      },
+      {
+        "id": "IATTC",
+        "label": "IATTC",
+        "alias": [
+          "CIAT",
+          "AIDCP",
+          "IDCP",
+          "Inter-American Tropical Tuna Commission",
+          "Comisión Interamericana del Atún Tropical",
+          "International Dolphin Conservation Program"
+        ],
+        "bounds": [[50.0642, -150.1172], [-50.2893, -71.7188]]
+      },
+      {
+        "id": "CCSBT",
+        "label": "CCSBT",
+        "alias": "Commission for the Conservation of Southern Bluefin Tuna",
+        "bounds": [[-30.1451, -20.3906], [-50.0642, 184.5703]]
+      }
+    ]
+  },
+};

--- a/src/routes/datasets.js
+++ b/src/routes/datasets.js
@@ -1,4 +1,5 @@
 const datasets = require("../data/datasets");
+const configData = require("../data/config");
 const log = require("../data/log");
 
 module.exports = app => {
@@ -36,6 +37,23 @@ module.exports = app => {
         return res.sendStatus(404);
       }
       return res.json(result);
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  app.get("/datasets/:dataset/config", async (req, res, next) => {
+    try {
+      // const id = req.swagger.params.dataset.value;
+
+      // log.debug(`Loading dataset ${id}`);
+      // const result = await datasets.get(id);
+      // if (!result) {
+      //   log.debug(`Dataset ${id} does not exist`);
+      //   return res.sendStatus(404);
+      // }
+      const config = await configData.get()
+      return res.json(config);
     } catch (error) {
       return next(error);
     }

--- a/src/routes/datasets.js
+++ b/src/routes/datasets.js
@@ -44,14 +44,15 @@ module.exports = app => {
 
   app.get("/datasets/:dataset/config", async (req, res, next) => {
     try {
-      // const id = req.swagger.params.dataset.value;
+      const id = req.swagger.params.dataset.value;
 
-      // log.debug(`Loading dataset ${id}`);
-      // const result = await datasets.get(id);
-      // if (!result) {
-      //   log.debug(`Dataset ${id} does not exist`);
-      //   return res.sendStatus(404);
-      // }
+      log.debug(`Loading dataset ${id}`);
+      const result = await datasets.get(id);
+      if (!result) {
+        log.debug(`Dataset ${id} does not exist`);
+        return res.sendStatus(404);
+      }
+      log.debug("Requesting dataset config");
       const config = await configData.get()
       return res.json(config);
     } catch (error) {


### PR DESCRIPTION
- [x] Adds static data config for carrier portal with swagger definition.
- [x] Allows to set a different port for the swagger documentation viewer with a root `.env` with fallback with the same port as before.